### PR TITLE
added extra two fields for Duo Security device type

### DIFF
--- a/src/onelogin/api/models/device.py
+++ b/src/onelogin/api/models/device.py
@@ -5,3 +5,5 @@ class Device(object):
     def __init__(self, data):
         self.id = data.get('device_id', None)
         self.type = data.get('device_type', '')
+        self.duo_api_hostname = data.get('duo_api_hostname', None)
+        self.duo_sig_request = data.get('duo_sig_request', None)


### PR DESCRIPTION
In documentation I have found following:

https://developers.onelogin.com/api-docs/1/login-page/create-session-login-token
When the device type is Duo Security, two additional elements are returned:
* `duo_sig_request`
* `duo_api_hostname`