### PR TITLE
Correctly handle pending responses

### DIFF
--- a/src/onelogin/api/client.py
+++ b/src/onelogin/api/client.py
@@ -119,15 +119,16 @@ class OneLoginClient(object):
         saml_endpoint_response = None
         try:
             content = response.json()
-            if content and 'status' in content and 'data' in content and 'message' in content['status'] and 'type' in content['status']:
+            if content and 'status' in content and 'message' in content['status'] and 'type' in content['status']:
                 status_type = content['status']['type']
                 status_message = content['status']['message']
                 saml_endpoint_response = SAMLEndpointResponse(status_type, status_message)
-                if status_message == 'Success':
-                    saml_endpoint_response.saml_response = content['data']
-                else:
-                    mfa = MFA(content['data'][0])
-                    saml_endpoint_response.mfa = mfa
+                if 'data' in content:
+                    if status_message == 'Success':
+                        saml_endpoint_response.saml_response = content['data']
+                    else:
+                        mfa = MFA(content['data'][0])
+                        saml_endpoint_response.mfa = mfa
         except:
             pass
         return saml_endpoint_response


### PR DESCRIPTION
The verify-factor endpoint may respond with pending.   Currently the `handle_saml_endpoint_response` function assumes that success entails the presence of a `data` field which is not the case when the otp verification is still pending.