### PR TITLE
Fix get requests from #execute_call

### DIFF
--- a/src/onelogin/api/client.py
+++ b/src/onelogin/api/client.py
@@ -1883,7 +1883,7 @@ class OneLoginClient(object):
         tries = 0
         while (tries < 2):
             if method == 'get':
-                response = requests.get(url, headers=headers, data=params)
+                response = requests.get(url, headers=headers, params=params)
             elif method == 'post':
                 response = requests.post(url, headers=headers, json=json)
             elif method == 'put':


### PR DESCRIPTION
According to http://docs.python-requests.org/en/master/user/quickstart/#passing-parameters-in-urls GET request's params should be passed with `params` option. 