### PR TITLE
Make onelogin a namespaced package

### DIFF
--- a/src/onelogin/__init__.py
+++ b/src/onelogin/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
see https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages

it'd be easier to extend the `onelogin` namespace eg. with [`onelogin/onelogin-python-aws-assume-role`](https://github.com/onelogin/onelogin-python-aws-assume-role)