### PR TITLE
Remove the dependency on lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.20.1
 defusedxml==0.5.0
-lxml==4.2.3
 python-dateutil==2.7.3

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     install_requires=[
         'requests==2.20.1',
         'defusedxml==0.5.0',
-        'lxml==4.2.3',
         'python-dateutil==2.7.3'
     ],
     test_suite='tests',

--- a/src/onelogin/api/client.py
+++ b/src/onelogin/api/client.py
@@ -208,13 +208,14 @@ class OneLoginClient(object):
     def retrieve_apps_from_xml(self, xml_content):
         root = fromstring(xml_content)
         node_list = root.findall("./apps/app")
-        attributes = ["id", "icon", "name", "provisioned", "extension_required", "personal", "login_id"]
+        attributes = {"id", "icon", "name", "provisioned", "extension_required", "personal", "login_id"}
         apps = []
         for node in node_list:
-            app_data = {}
-            for children in node:
-                if children.tag in attributes:
-                    app_data.attrib[children.tag] = children.text
+            app_data = {
+                child.tag: child.text
+                for child in node
+                if child.tag in attributes
+            }
             apps.append(EmbedApp(app_data))
         return apps
 

--- a/src/onelogin/api/client.py
+++ b/src/onelogin/api/client.py
@@ -12,7 +12,7 @@ OneLoginClient class of the OneLogin's Python SDK.
 import datetime
 from dateutil import tz
 import requests
-from defusedxml.lxml import fromstring
+from defusedxml.ElementTree import fromstring
 
 from onelogin.api.util.urlbuilder import UrlBuilder
 from onelogin.api.util.constants import Constants
@@ -207,14 +207,14 @@ class OneLoginClient(object):
 
     def retrieve_apps_from_xml(self, xml_content):
         root = fromstring(xml_content)
-        node_list = root.xpath("/apps/app")
+        node_list = root.findall("./apps/app")
         attributes = ["id", "icon", "name", "provisioned", "extension_required", "personal", "login_id"]
         apps = []
         for node in node_list:
             app_data = {}
-            for children in node.getchildren():
+            for children in node:
                 if children.tag in attributes:
-                    app_data[children.tag] = children.text
+                    app_data.attrib[children.tag] = children.text
             apps.append(EmbedApp(app_data))
         return apps
 

--- a/src/onelogin/api/client.py
+++ b/src/onelogin/api/client.py
@@ -207,7 +207,7 @@ class OneLoginClient(object):
 
     def retrieve_apps_from_xml(self, xml_content):
         root = fromstring(xml_content)
-        node_list = root.findall("./apps/app")
+        node_list = root.findall("./app")
         attributes = {"id", "icon", "name", "provisioned", "extension_required", "personal", "login_id"}
         apps = []
         for node in node_list:


### PR DESCRIPTION
Lxml is a pretty heavyweight dependency, especially if you're installing this in an environment that is not able to install `.whl` files.

As far as I can tell this module uses `lxml` in only a single place, for a very simple operation. I think we can easily and safely replace this with an ElementTree-based parser instead?