### PR TITLE
Loosen dependency requirements

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,3 @@ jobs:
       run: |
         coverage run --source=src/onelogin/api --rcfile=tests/coverage.rc setup.py test
         coverage report -m --rcfile=tests/coverage.rc
-    - name: Coveralls
-      run: |
-        coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-nose==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-requests==2.20.1
-defusedxml==0.5.0
-python-dateutil==2.7.3

--- a/setup.py
+++ b/setup.py
@@ -38,17 +38,17 @@ setup(
         '': 'src',
     },
     install_requires=[
-        'requests',
-        'defusedxml',
-        'python-dateutil'
+        'requests>=2,<3',
+        'defusedxml>=0.5',
+        'python-dateutil>=2,<3'
     ],
     test_suite='tests',
     extras_require={
         'test': (
-            'coverage',
-            'pylint',
-            'pep8',
-            'pyflakes',
+            'coverage>=3,<6',
+            'pylint>=1,<3',
+            'pep8>=1,<2',
+            'pyflakes>=1,<3',
             'coveralls',
         ),
     },

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
             'pylint>=1,<3',
             'pep8>=1,<2',
             'pyflakes>=1,<3',
-            'coveralls',
         ),
     },
     keywords='onelogin api sdk',)

--- a/setup.py
+++ b/setup.py
@@ -38,18 +38,18 @@ setup(
         '': 'src',
     },
     install_requires=[
-        'requests==2.20.1',
-        'defusedxml==0.5.0',
-        'python-dateutil==2.7.3'
+        'requests',
+        'defusedxml',
+        'python-dateutil'
     ],
     test_suite='tests',
     extras_require={
         'test': (
-            'coverage==3.7.1',
-            'pylint==1.3.1',
-            'pep8==1.5.7',
-            'pyflakes==0.8.1',
-            'coveralls==0.4.4',
+            'coverage',
+            'pylint',
+            'pep8',
+            'pyflakes',
+            'coveralls',
         ),
     },
     keywords='onelogin api sdk',)


### PR DESCRIPTION
Closes #32

Requirements shouldn't be tied to specific versions. All requirements have been left open and we should only limit by upper and lower bounds when concrete compatibility issues are identified.