### PR TITLE
fix: dict-keys cannot be subscription error

### DIFF
--- a/src/onelogin/api/util/urlbuilder.py
+++ b/src/onelogin/api/util/urlbuilder.py
@@ -9,7 +9,6 @@ UrlBuilder class of the OneLogin's Python SDK.
 
 """
 from onelogin.api.util.endpoints import Endpoints
-
 import sys
 if sys.version_info[0] >= 3:
     unicode = str
@@ -60,8 +59,8 @@ class UrlBuilder(object):
 
         version = None
         if resource_data is not None:
-            resource = resource_data.keys()[0]
-            resource_values = resource_data.values()[0]
+            resource = next(iter(resource_data))
+            resource_values = resource_data[resource]
             if resource not in api_configuration.keys():
                 version = resource_values[-1]
             elif api_configuration[resource] in resource_values:

--- a/tests/src/onelogin/client_test.py
+++ b/tests/src/onelogin/client_test.py
@@ -60,3 +60,14 @@ class OneLogin_API_Client_Test(unittest.TestCase):
         )
         self.assertIsNone(client.error)
         self.assertIsNone(client.error_description)
+
+    def testGetVersionID(self):
+        """
+        Tests the method to get endpoint version
+        """
+        client = OneLoginClient(
+            client_id='test_client_id',
+            client_secret='test_client_secret',
+        )
+        version = client.get_version_id('GET_APPS_URL')
+        self.assertEqual(version, 1)


### PR DESCRIPTION
This should fix #53, and https://github.com/physera/onelogin-aws-cli/issues/151

Because the master branch is behind 2.0.0, so I temporarily set the base branch to 2.0.0.