### PR TITLE
Issue #98: Fix packaging configuration to include all subdirectories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["setuptools>=67.7.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["onelogin"]
+packages = {find = {}}
 package-dir = {"" = "."}
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["setuptools>=67.7.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = {find = {}}
+packages = {find = {exclude = ["tests*", "docs*"]}}
 package-dir = {"" = "."}
 include-package-data = true
 


### PR DESCRIPTION
- Change packages = ["onelogin"] to packages = {find = {}}
- This ensures onelogin.api and onelogin.models are included in the package
- Fixes ImportError: No module named 'onelogin.api'

This PR resolves issue #98. I don't have a Jira ticket number, I'm not sure where to get that.

This pull request updates the packaging configuration in `pyproject.toml` to improve how packages are discovered and included. The change ensures that only relevant source code is packaged, excluding test and documentation directories.

Packaging improvements:

* Updated the `packages` setting to use `find` and explicitly exclude `tests*` and `docs*` directories from the package distribution, ensuring a cleaner package and reducing unnecessary files in releases.