### PR TITLE
Issue #100: Fix User.manager_user_id type: change from StrictStr to StrictInt

### DIFF
--- a/onelogin/models/user.py
+++ b/onelogin/models/user.py
@@ -37,7 +37,7 @@ class User(BaseModel):
     directory_id: Optional[StrictInt] = Field(None, description="The ID of the OneLogin Directory of the user.")
     trusted_idp_id: Optional[StrictInt] = Field(None, description="The ID of the OneLogin Trusted IDP of the user.")
     manager_ad_id: Optional[StrictStr] = Field(None, description="The ID of the user's manager in Active Directory.")
-    manager_user_id: Optional[StrictStr] = Field(None, description="The OneLogin User ID for the user's manager.")
+    manager_user_id: Optional[StrictInt] = Field(None, description="The OneLogin User ID for the user's manager.")
     samaccountname: Optional[StrictStr] = Field(None, description="The user's Active Directory username.")
     member_of: Optional[StrictStr] = Field(None, description="The user's directory membership.")
     userprincipalname: Optional[StrictStr] = Field(None, description="The principle name of the user.")


### PR DESCRIPTION
* Change `User.manager_user_id` from `StrictStr` to `StrictInt`.

This pull request makes a small update to the `User` model to improve type consistency. The most important change is updating the type of the `manager_user_id` field from `StrictStr` to `StrictInt`, ensuring that it matches the expected format for OneLogin User IDs.