### PR TITLE
chore: bump pyproject version to 3.2.8 + gitignore stale clones [no-ado]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 .DS_Store
 
 **/.claude/settings.local.json
+
+# Stale self-clones that occasionally appear in the repo root
+/onelogin-python-sdk/

--- a/onelogin/__init__.py
+++ b/onelogin/__init__.py
@@ -9,7 +9,7 @@
 """
 
 
-__version__ = "3.2.6"
+__version__ = "3.2.8"
 
 # import apis into sdk package
 from onelogin.api.api_auth_claims_api import APIAuthClaimsApi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onelogin"
-version = "3.2.6"
+version = "3.2.8"
 description = "OneLogin API Python SDK"
 authors = [
     {name = "OneLogin", email = "developers@onelogin.com"}


### PR DESCRIPTION
## Summary

Two trivial housekeeping items in one PR — no functional change.

1. **Reconcile `pyproject.toml` version**: was stuck at `3.2.6` while PyPI is now `3.2.8`. The publish workflow extracts version from the git tag, so this didn't block releases, but anyone running \`pip install -e .\` against \`main\` got a misleading version string. Also updates \`onelogin/__init__.__version__\`.

2. **Gitignore stale self-clones**: adds \`/onelogin-python-sdk/\` to \`.gitignore\`. A clone of the repo had appeared under the repo root (probably from extracting a release tarball at some point). It was untracked and harmless, but caused grep noise and confused diff-tooling.

## Test plan

- [x] \`pytest test/\` — 358 passed