### PR TITLE
chore: add ruff to CI, fix 2 latent bugs, bump action versions [no-ado]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,19 @@ name: Continuous Integration
 on: [push]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install ruff
+      run: pip install -e ".[lint]"
+    - name: Ruff check
+      run: ruff check .
+
   build:
 
     runs-on: ubuntu-latest
@@ -12,9 +25,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/onelogin/api/api_auth_claims_api.py
+++ b/onelogin/api/api_auth_claims_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictInt, StrictStr
 

--- a/onelogin/api/api_auth_client_apps_api.py
+++ b/onelogin/api/api_auth_client_apps_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictInt, StrictStr
 

--- a/onelogin/api/api_auth_scopes_api.py
+++ b/onelogin/api/api_auth_scopes_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictInt, StrictStr
 

--- a/onelogin/api/api_authorization_server_api.py
+++ b/onelogin/api/api_authorization_server_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictStr
 

--- a/onelogin/api/app_rules_api.py
+++ b/onelogin/api/app_rules_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, conlist

--- a/onelogin/api/apps_api.py
+++ b/onelogin/api/apps_api.py
@@ -9,11 +9,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictInt, StrictStr
 

--- a/onelogin/api/branding_service_api.py
+++ b/onelogin/api/branding_service_api.py
@@ -9,10 +9,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt

--- a/onelogin/api/branding_service_smtp_api.py
+++ b/onelogin/api/branding_service_smtp_api.py
@@ -9,11 +9,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from typing import Optional
 

--- a/onelogin/api/branding_service_templates_api.py
+++ b/onelogin/api/branding_service_templates_api.py
@@ -8,13 +8,11 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictInt, StrictStr, constr, validator
+from pydantic import Field, StrictInt, StrictStr, constr
 
 from typing import List, Optional
 

--- a/onelogin/api/events_api.py
+++ b/onelogin/api/events_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr, conlist

--- a/onelogin/api/groups_api.py
+++ b/onelogin/api/groups_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictStr
 

--- a/onelogin/api/invite_links_api.py
+++ b/onelogin/api/invite_links_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from typing import Optional
 

--- a/onelogin/api/multi_factor_authentication_api.py
+++ b/onelogin/api/multi_factor_authentication_api.py
@@ -8,15 +8,13 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from onelogin.models.create_device_verification201_response import CreateDeviceVerification201Response
 from onelogin.models.create_device_verification_request import CreateDeviceVerificationRequest

--- a/onelogin/api/multi_factor_authentication_v1_api.py
+++ b/onelogin/api/multi_factor_authentication_v1_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr

--- a/onelogin/api/o_auth2_api.py
+++ b/onelogin/api/o_auth2_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr

--- a/onelogin/api/privileges_api.py
+++ b/onelogin/api/privileges_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr

--- a/onelogin/api/roles_api.py
+++ b/onelogin/api/roles_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, conlist

--- a/onelogin/api/saml_assertions_api.py
+++ b/onelogin/api/saml_assertions_api.py
@@ -8,11 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
-from typing_extensions import Annotated
+from pydantic import validate_call
 
 from pydantic import StrictStr
 

--- a/onelogin/api/smart_hooks_api.py
+++ b/onelogin/api/smart_hooks_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr

--- a/onelogin/api/user_mappings_api.py
+++ b/onelogin/api/user_mappings_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, conlist

--- a/onelogin/api/users_v1_api.py
+++ b/onelogin/api/users_v1_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr

--- a/onelogin/api/users_v2_api.py
+++ b/onelogin/api/users_v2_api.py
@@ -8,10 +8,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr

--- a/onelogin/api/vigilance_ai_api.py
+++ b/onelogin/api/vigilance_ai_api.py
@@ -9,10 +9,8 @@
 
 
 import re  # noqa: F401
-import io
-import warnings
 
-from pydantic import validate_call, ValidationError
+from pydantic import validate_call
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr

--- a/onelogin/configuration.py
+++ b/onelogin/configuration.py
@@ -15,7 +15,6 @@ import sys
 import urllib3
 
 import http.client as httplib
-from onelogin.exceptions import ApiValueError
 
 JSON_SCHEMA_VALIDATION_KEYWORDS = {
     'multipleOf', 'maximum', 'exclusiveMaximum',

--- a/onelogin/models/action_obj.py
+++ b/onelogin/models/action_obj.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, conlist
 
 class ActionObj(BaseModel):

--- a/onelogin/models/add_client_app_request.py
+++ b/onelogin/models/add_client_app_request.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, conlist
 
 class AddClientAppRequest(BaseModel):

--- a/onelogin/models/add_privilege_to_role_request.py
+++ b/onelogin/models/add_privilege_to_role_request.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, StrictInt, conlist
 
 class AddPrivilegeToRoleRequest(BaseModel):

--- a/onelogin/models/add_roles_to_user_request.py
+++ b/onelogin/models/add_roles_to_user_request.py
@@ -13,7 +13,6 @@ import re  # noqa: F401
 import json
 
 
-from typing import List
 from pydantic import BaseModel, Field, StrictInt, conlist
 
 class AddRolesToUserRequest(BaseModel):

--- a/onelogin/models/app_rule.py
+++ b/onelogin/models/app_rule.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist, field_validator
 from onelogin.models.action_obj import ActionObj
 from onelogin.models.condition import Condition

--- a/onelogin/models/assign_users_to_privilege_request.py
+++ b/onelogin/models/assign_users_to_privilege_request.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, StrictInt, conlist
 
 class AssignUsersToPrivilegeRequest(BaseModel):

--- a/onelogin/models/auth_method.py
+++ b/onelogin/models/auth_method.py
@@ -7,10 +7,10 @@
 """
 
 
+from __future__ import annotations
 import json
-import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from aenum import Enum
 
 
 

--- a/onelogin/models/auth_server_configuration.py
+++ b/onelogin/models/auth_server_configuration.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 
 class AuthServerConfiguration(BaseModel):

--- a/onelogin/models/client_app_full.py
+++ b/onelogin/models/client_app_full.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 from onelogin.models.scope import Scope
 

--- a/onelogin/models/create_app200_response.py
+++ b/onelogin/models/create_app200_response.py
@@ -8,18 +8,16 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import json
 import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 from onelogin.models.generic_app import GenericApp
 from onelogin.models.oidc_app import OidcApp
 from onelogin.models.saml_app import SamlApp
-from typing import Any, List, Literal, ClassVar
-from pydantic import StrictStr, Field
+from typing import Literal, ClassVar
 
 CREATEAPP200RESPONSE_ONE_OF_SCHEMAS = ["GenericApp", "OidcApp", "SamlApp"]
 

--- a/onelogin/models/create_app_request.py
+++ b/onelogin/models/create_app_request.py
@@ -8,18 +8,16 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import json
 import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 from onelogin.models.generic_app import GenericApp
 from onelogin.models.oidc_app import OidcApp
 from onelogin.models.saml_app import SamlApp
-from typing import Any, List, Literal
-from pydantic import StrictStr, Field
+from typing import Literal
 
 CREATEAPPREQUEST_ONE_OF_SCHEMAS = ["GenericApp", "OidcApp", "SamlApp"]
 

--- a/onelogin/models/create_privilege200_response.py
+++ b/onelogin/models/create_privilege200_response.py
@@ -8,7 +8,6 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import pprint
 import re  # noqa: F401
 import json

--- a/onelogin/models/enroll_mfa_factor200_response.py
+++ b/onelogin/models/enroll_mfa_factor200_response.py
@@ -15,7 +15,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.get_enrolled_factors200_response_data_otp_devices_inner import GetEnrolledFactors200ResponseDataOtpDevicesInner

--- a/onelogin/models/generate_saml_assert200_response.py
+++ b/onelogin/models/generate_saml_assert200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 

--- a/onelogin/models/get_assigned_user200_response.py
+++ b/onelogin/models/get_assigned_user200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 
 class GetAssignedUser200Response(BaseModel):

--- a/onelogin/models/get_custom_attributes200_response.py
+++ b/onelogin/models/get_custom_attributes200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, conlist
 from onelogin.models.error import Error
 

--- a/onelogin/models/get_email_settings200_response.py
+++ b/onelogin/models/get_email_settings200_response.py
@@ -8,17 +8,15 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import json
 import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 from onelogin.models.email_config import EmailConfig
 from onelogin.models.get_email_settings200_response_one_of import GetEmailSettings200ResponseOneOf
-from typing import Any, List, Literal
-from pydantic import StrictStr, Field
+from typing import Literal
 
 GETEMAILSETTINGS200RESPONSE_ONE_OF_SCHEMAS = ["EmailConfig", "GetEmailSettings200ResponseOneOf"]
 

--- a/onelogin/models/get_enrolled_factors200_response_data.py
+++ b/onelogin/models/get_enrolled_factors200_response_data.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.get_enrolled_factors200_response_data_otp_devices_inner import GetEnrolledFactors200ResponseDataOtpDevicesInner
 

--- a/onelogin/models/get_event_types200_response.py
+++ b/onelogin/models/get_event_types200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.get_event_types200_response_data_inner import GetEventTypes200ResponseDataInner

--- a/onelogin/models/get_events200_response.py
+++ b/onelogin/models/get_events200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.event import Event

--- a/onelogin/models/get_groups200_response.py
+++ b/onelogin/models/get_groups200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.group import Group

--- a/onelogin/models/get_invite_link200_response.py
+++ b/onelogin/models/get_invite_link200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, conlist
 from onelogin.models.error import Error
 

--- a/onelogin/models/get_mfa_factors200_response_data.py
+++ b/onelogin/models/get_mfa_factors200_response_data.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.get_mfa_factors200_response_data_auth_factors_inner import GetMFAFactors200ResponseDataAuthFactorsInner
 

--- a/onelogin/models/get_risk_score200_response.py
+++ b/onelogin/models/get_risk_score200_response.py
@@ -14,7 +14,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, confloat, conlist
 
 class GetRiskScore200Response(BaseModel):

--- a/onelogin/models/get_role_by_id200_response.py
+++ b/onelogin/models/get_role_by_id200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.get_role_by_id200_response_data_inner import GetRoleById200ResponseDataInner

--- a/onelogin/models/get_role_by_name200_response.py
+++ b/onelogin/models/get_role_by_name200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, conlist
 from onelogin.models.error import Error
 from onelogin.models.get_role_by_name200_response_data_inner import GetRoleByName200ResponseDataInner

--- a/onelogin/models/get_user_roles200_response.py
+++ b/onelogin/models/get_user_roles200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, conlist
 from onelogin.models.error import Error
 

--- a/onelogin/models/hook.py
+++ b/onelogin/models/hook.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conint, conlist, field_validator
 from onelogin.models.condition import Condition
 from onelogin.models.hook_options import HookOptions

--- a/onelogin/models/hook_log.py
+++ b/onelogin/models/hook_log.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, StrictStr, conlist
 
 class HookLog(BaseModel):

--- a/onelogin/models/list_privelege_roles200_response.py
+++ b/onelogin/models/list_privelege_roles200_response.py
@@ -8,13 +8,12 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import pprint
 import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 
 class ListPrivelegeRoles200Response(BaseModel):

--- a/onelogin/models/list_privilege_roles200_response.py
+++ b/onelogin/models/list_privilege_roles200_response.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 
 class ListPrivilegeRoles200Response(BaseModel):

--- a/onelogin/models/mapping.py
+++ b/onelogin/models/mapping.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, ValidationError, conlist, field_validator
 from onelogin.models.action_obj import ActionObj
 from onelogin.models.condition import Condition

--- a/onelogin/models/message_template_template.py
+++ b/onelogin/models/message_template_template.py
@@ -8,17 +8,15 @@
 
 
 from __future__ import annotations
-from inspect import getfullargspec
 import json
 import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 from onelogin.models.message_template_template_one_of import MessageTemplateTemplateOneOf
 from onelogin.models.message_template_template_one_of1 import MessageTemplateTemplateOneOf1
-from typing import Any, List, Literal
-from pydantic import StrictStr
+from typing import Literal
 
 MESSAGETEMPLATETEMPLATE_ONE_OF_SCHEMAS = ["MessageTemplateTemplateOneOf", "MessageTemplateTemplateOneOf1"]
 

--- a/onelogin/models/oidc_app.py
+++ b/onelogin/models/oidc_app.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist
 from onelogin.models.app_parameters import AppParameters
 from onelogin.models.auth_method import AuthMethod

--- a/onelogin/models/privilege_privilege.py
+++ b/onelogin/models/privilege_privilege.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, conlist
 from onelogin.models.privilege_privilege_statement_inner import PrivilegePrivilegeStatementInner
 

--- a/onelogin/models/privilege_privilege_statement_inner.py
+++ b/onelogin/models/privilege_privilege_statement_inner.py
@@ -14,7 +14,6 @@ import re  # noqa: F401
 import json
 
 
-from typing import List
 from pydantic import BaseModel, Field, StrictStr, conlist, field_validator
 
 class PrivilegePrivilegeStatementInner(BaseModel):

--- a/onelogin/models/remove_role_users_request.py
+++ b/onelogin/models/remove_role_users_request.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, StrictInt, conlist
 
 class RemoveRoleUsersRequest(BaseModel):

--- a/onelogin/models/remove_user_role_request.py
+++ b/onelogin/models/remove_user_role_request.py
@@ -13,7 +13,6 @@ import re  # noqa: F401
 import json
 
 
-from typing import List
 from pydantic import BaseModel, conlist
 from onelogin.models.remove_user_role_request_role_id_array_inner import RemoveUserRoleRequestRoleIdArrayInner
 

--- a/onelogin/models/risk_rule.py
+++ b/onelogin/models/risk_rule.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictStr, conlist, field_validator
 from onelogin.models.source import Source
 

--- a/onelogin/models/role.py
+++ b/onelogin/models/role.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
 
 class Role(BaseModel):

--- a/onelogin/models/saml_app.py
+++ b/onelogin/models/saml_app.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist
 from onelogin.models.auth_method import AuthMethod
 from onelogin.models.configuration_saml import ConfigurationSaml

--- a/onelogin/models/token_claim.py
+++ b/onelogin/models/token_claim.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist
 
 class TokenClaim(BaseModel):

--- a/onelogin/models/update_client_app_request.py
+++ b/onelogin/models/update_client_app_request.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import Optional
 from pydantic import BaseModel, Field, StrictInt, conlist
 
 class UpdateClientAppRequest(BaseModel):

--- a/onelogin/models/user.py
+++ b/onelogin/models/user.py
@@ -13,7 +13,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist, field_validator
 
 class User(BaseModel):

--- a/onelogin/models/verb.py
+++ b/onelogin/models/verb.py
@@ -7,10 +7,10 @@
 """
 
 
+from __future__ import annotations
 import json
-import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from aenum import Enum
 
 
 

--- a/onelogin/rest.py
+++ b/onelogin/rest.py
@@ -13,7 +13,6 @@ import logging
 import re
 import ssl
 
-from urllib.parse import urlencode, quote_plus
 import urllib3
 
 from onelogin.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ test = [
     "flake8>=4.0.0",
     "tox>=3.9.0",
 ]
+lint = [
+    "ruff>=0.6.0",
+]
 
 [project.urls]
 Repository = "https://github.com/onelogin/onelogin-python-sdk"
@@ -47,3 +50,37 @@ max-line-length = 99
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.ruff]
+line-length = 120
+# Only lint the package itself for now. test/ will be added once the stub-file
+# cleanup (PR #129) lands — most current test/ ruff hits live in those stubs.
+include = ["onelogin/**/*.py"]
+
+[tool.ruff.lint]
+# Pyflakes (F) + pycodestyle errors (E) is the safe starter set.
+select = ["E", "F"]
+# Generator-era api/ files have method signatures up to ~2,800 chars on a
+# single line. Line-length lint isn't worth fighting on legacy code; the
+# real value here is F-rules (unused imports, undefined names) and E7xx
+# (real code smells).
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-exports — `# flake8: noqa` already covers F401 here, but be explicit.
+"onelogin/__init__.py" = ["F401"]
+"onelogin/models/__init__.py" = ["F401"]
+"onelogin/api/__init__.py" = ["F401"]
+# Generator-leftover dead assignments in `oneOf` validators. Cosmetic only;
+# safe to clean up in a follow-up sweep.
+"onelogin/models/create_app200_response.py" = ["F841"]
+"onelogin/models/create_app_request.py" = ["F841"]
+"onelogin/models/create_role201_response_inner.py" = ["F841"]
+"onelogin/models/get_email_settings200_response.py" = ["F841"]
+"onelogin/models/list_mappings_actions200_response_inner.py" = ["F841"]
+"onelogin/models/message_template_template.py" = ["F841"]
+# `query_params = {}` after an early-return-style branch in the rest client.
+"onelogin/rest.py" = ["F841"]
+# `type(x) == str` in two places — works, but should use `isinstance`.
+# Low-level deserializer, follow-up.
+"onelogin/api_client.py" = ["E721"]


### PR DESCRIPTION
## Summary

Wires up linting and removes two real latent bugs that had been sitting in the codebase undetected.

## Latent bugs found (and fixed)

Two F821 (undefined-name) errors in self-referential type hints:

- \`onelogin/models/auth_method.py:38\` — \`def from_json(cls, json_str: str) -> AuthMethod\`
- \`onelogin/models/verb.py:35\` — \`def from_json(cls, json_str: str) -> Verb\`

Both files used the class name in a method type annotation but were missing \`from __future__ import annotations\`. Other model files (e.g., \`mapping.py\`) already had this import. Without it, calling \`AuthMethod.from_json(...)\` or \`Verb.from_json(...)\` would fail at runtime with \`NameError\`. Never caught by tests because no test exercised that method on these enums.

These are exactly the kind of bugs ruff catches for free — and exactly why we want it in CI.

## Auto-fixes applied

\`ruff check --fix\` cleaned 162 issues in \`onelogin/\`:
- ~140 F401 unused imports (\`import io\`, \`import warnings\`, etc. the generator added but nothing referenced)
- 15 F811 (re-import-while-unused)
- Various other safe F-rule fixes

72 files modified. Verified imports still work and 358 tests still pass.

## CI changes

- **New \`lint\` job** runs alongside the existing \`build\` job and gates merges on \`ruff check .\` passing.
- \`actions/checkout@v1\` → \`@v4\` and \`actions/setup-python@v1\` → \`@v5\` (the v1 versions are years EOL).

## Ruff config (pyproject.toml)

Conservative starter rule set: \`E\` + \`F\`, with:
- \`E501\` (line-length) **disabled** — generator-era api/ files have method signatures up to ~2,800 chars on a single line. Not worth fighting on legacy code.
- \`include = ["onelogin/**/*.py"]\` — \`test/\` is excluded from ruff for now. Most current \`test/\` ruff hits are in the 178 stub files that PR #129 deletes. **After #129 lands, \`test/\` should be added to the lint scope.**

## Per-file-ignores (acknowledged debt)

Suppresses 7 F841/E721 issues that are real but minor generator leftovers:
- Dead \`instance = X.construct()\` assignments in 6 \`oneOf\` validator methods
- One \`query_params = {}\` assignment-after-conditional in \`onelogin/rest.py\`
- Two \`type(x) == str\` style comparisons in \`onelogin/api_client.py\` (should use \`isinstance\`)

These should be cleaned up in a follow-up; flagging them in CI now would block this PR for cosmetic reasons.

## Test plan

- [x] \`ruff check .\` — passes
- [x] \`pytest test/\` — 358 passed
- [x] Smoke imports: \`from onelogin.api.users_v2_api import UsersV2Api\`, \`from onelogin.models.mapping import Mapping\` — both work
- [x] Confirmed the two F821 cases were real (manually constructed the forward-reference issue in a REPL)

## Follow-ups (out of scope for this PR)

- Add \`test/\` to ruff scope once #129 (stub deletion) lands.
- Address the 7 acknowledged F841/E721 issues with real fixes instead of ignores.
- Consider expanding the ruff rule set (\`I\` for import sorting, \`UP\` for pyupgrade, etc.) once the baseline is stable.