### PR TITLE
fix: allow null description on AuthServer responses [no-ado]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.2.9 (2026-05-12)
+
+### Bug Fixes
+
+- **`get_authorization_server`** (`GET /api/2/api_authorizations/{id}`): Auth servers
+  are implemented as Apps rows with `auth_type=9`. The underlying `apps.description`
+  column is nullable in core-api, so the endpoint returns `"description": null` for
+  any auth server created without a description. The SDK had typed `AuthServer.description`
+  as required `StrictStr`, causing pydantic `ValidationError` on those responses.
+  `description` is now `Optional[StrictStr]` (defaulting to `None`), so null/absent
+  descriptions deserialize correctly. The existing `exclude_none=True` in `to_dict`
+  drops it from request bodies when unset.
+
 ## 3.2.8 (2026-05-12)
 
 ### Bug Fixes

--- a/onelogin/models/auth_server.py
+++ b/onelogin/models/auth_server.py
@@ -23,7 +23,7 @@ class AuthServer(BaseModel):
     """
     id: Optional[StrictInt] = Field(None, description="Auth server unique ID in Onelogin")
     name: StrictStr = Field(..., description="Name of the API.")
-    description: StrictStr = Field(..., description="Description of what the API does.")
+    description: Optional[StrictStr] = Field(None, description="Description of what the API does.")
     configuration: AuthServerConfiguration = ...
     __properties = ["id", "name", "description", "configuration"]
 

--- a/test/test_auth_server.py
+++ b/test/test_auth_server.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+
+import unittest
+
+from onelogin.models.auth_server import AuthServer
+from onelogin.models.auth_server_configuration import AuthServerConfiguration
+
+
+class TestAuthServer(unittest.TestCase):
+    """AuthServer model tests — focused on the nullable-description bug class."""
+
+    def _make_payload(self, description="A description"):
+        return {
+            "id": 123,
+            "name": "Test API",
+            "description": description,
+            "configuration": {
+                "resource_identifier": "https://example.com/api",
+                "audiences": ["https://example.com/api"],
+                "access_token_expiration_minutes": 10,
+                "refresh_token_expiration_minutes": 480,
+            },
+        }
+
+    def test_from_dict_with_description(self):
+        result = AuthServer.from_dict(self._make_payload(description="A real description"))
+        self.assertIsInstance(result, AuthServer)
+        self.assertEqual(result.description, "A real description")
+
+    def test_from_dict_with_null_description(self):
+        """Auth servers (apps with auth_type=9) can have apps.description = NULL."""
+        result = AuthServer.from_dict(self._make_payload(description=None))
+        self.assertIsInstance(result, AuthServer)
+        self.assertIsNone(result.description)
+
+    def test_from_dict_without_description(self):
+        data = self._make_payload()
+        del data["description"]
+        result = AuthServer.from_dict(data)
+        self.assertIsInstance(result, AuthServer)
+        self.assertIsNone(result.description)
+
+    def test_to_dict_excludes_none_description(self):
+        config = AuthServerConfiguration(
+            resource_identifier="https://example.com/api",
+            audiences=["https://example.com/api"],
+            access_token_expiration_minutes=10,
+            refresh_token_expiration_minutes=480,
+        )
+        server = AuthServer(name="Test API", description=None, configuration=config)
+        d = server.to_dict()
+        self.assertNotIn("description", d)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Relaxes \`AuthServer.description\` from required \`StrictStr\` to \`Optional[StrictStr]\` to fix a pydantic \`ValidationError\` when \`GET /api/2/api_authorizations/{id}\` returns an auth server with no description.

## Root cause

Auth servers in OneLogin are implemented as **Apps rows with \`auth_type=9\`** (confirmed today). The underlying \`apps.description\` column is declared as \`t.text "description"\` in \`core-api/db/schema.rb\` with no \`null: false\` constraint, so it's nullable by Rails default. Any auth server created without a description is stored as \`apps.description = NULL\` and serialized back to the client as \`"description": null\`.

The SDK had \`description: StrictStr = Field(..., ...)\` which rejects \`None\`. Same bug class as PR #126 (\`Mapping.position\`).

## Change

One-line model relaxation:

\`\`\`diff
- description: StrictStr = Field(..., description="Description of what the API does.")
+ description: Optional[StrictStr] = Field(None, description="Description of what the API does.")
\`\`\`

The existing \`exclude_none=True\` in \`to_dict()\` already drops the field from request bodies when unset, so no other model changes are needed.

## Tests

New \`test/test_auth_server.py\` with the standard four-case nullability pattern (matches the shape of \`test_mapping.py::test_from_dict_with_null_position\`):

- \`test_from_dict_with_description\` — happy path, value preserved
- \`test_from_dict_with_null_description\` — the actual bug scenario
- \`test_from_dict_without_description\` — missing-key variant
- \`test_to_dict_excludes_none_description\` — serialization drops \`None\`

## Test plan

- [x] \`pytest test/test_auth_server.py\` — 4 new tests pass
- [x] \`pytest test/\` — 70 passed (66 existing + 4 new), no regressions
- [x] \`ruff check .\` — clean

## Source for the audit

This fix was the only LEGIT finding from the broader StrictField nullability audit run after PR #130 merged. The other T2 candidates either:
- Were in \`*_request\` models where required+strict is correct (SDK validates user input before sending), or
- Were in orphan models that no SDK API method actually deserializes (separate cleanup coming as a 4.0.0 PR)

So this is the entire customer-facing surface area from the audit.