### PR TITLE
docs: shorten README and fix two inaccuracies [no-ado]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,85 @@
 # onelogin-python-sdk
 
-Official Python SDK for the OneLogin API, enabling you to programmatically manage users, roles, groups, and authentication in your OneLogin instance.
+Official Python SDK for the OneLogin API. Manage users, roles, groups, apps, and authentication programmatically.
 
-For more information about the OneLogin API, visit the [OneLogin API Documentation](https://developers.onelogin.com/api-docs/2/getting-started/dev-overview).
+API reference: [OneLogin API Documentation](https://developers.onelogin.com/api-docs/2/getting-started/dev-overview).
+Per-endpoint docs: see [`docs/`](docs/) in this repo.
 
 ## Support
-OneLogin by One Identity open source projects are supported through [OneLogin GitHub issues](https://github.com/onelogin/onelogin-python-sdk/issues). This includes all scripts, plugins, SDKs, modules, code snippets or other solutions. For assistance with any OneLogin by One Identity GitHub project, please raise a new Issue on the [OneLogin GitHub issues](https://github.com/onelogin/onelogin-python-sdk/issues) page. Requests for assistance made through official One Identity Support will be referred back to GitHub where those requests can benefit all users.
+
+OneLogin by One Identity open-source projects are supported through GitHub. For help, please open an issue: <https://github.com/onelogin/onelogin-python-sdk/issues>. Requests filed via official One Identity Support are redirected here so all users can benefit.
 
 ## Requirements
 
 - Python 3.10+
-- Dependencies:
-  - Pydantic 2.11+ (latest version)
-  - urllib3 2.0.2+
-  - python-dateutil 2.5.3+
-  - aenum 3.1.11+
+- Pydantic 2.11+ (enforced via `pyproject.toml`)
 
-## Installation & Usage
-
-### pip install
-
-You can install directly using pip:
+## Installation
 
 ```sh
 pip install onelogin
 ```
 
-For development and testing, install with test dependencies:
+For development:
 
 ```sh
-pip install onelogin[test]
-```
-
-Then import the package:
-
-```python
-import onelogin
-```
-
-### Tests
-
-First, install the package with test dependencies:
-
-```sh
-pip install -e .[test]
-```
-
-Then run the tests:
-
-```sh
-pytest
+pip install -e ".[test,lint]"
 ```
 
 ## Getting Started
 
-Please follow the [installation procedure](#installation--usage) and then run the following:
-
 ```python
-
 import os
 import onelogin
-from onelogin.rest import ApiException
 from pprint import pprint
 
-# Set up configuration
-# Replace 'your-subdomain' with your actual OneLogin subdomain
 configuration = onelogin.Configuration(
-    host = "https://your-subdomain.onelogin.com"
+    host="https://your-subdomain.onelogin.com",
+    username=os.environ["ONELOGIN_CLIENT_ID"],
+    password=os.environ["ONELOGIN_CLIENT_SECRET"],
 )
 
-# Set your API credentials
-# Use environment variables to avoid hardcoding credentials
-# IMPORTANT: Use ONELOGIN_CLIENT_ID and ONELOGIN_CLIENT_SECRET for your environment variables
-configuration = onelogin.Configuration(
-    username = os.environ["ONELOGIN_CLIENT_ID"],
-    password = os.environ["ONELOGIN_CLIENT_SECRET"]
-)
-
-# Enter a context with an instance of the API client
 with onelogin.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    token_instance = onelogin.OAuth2Api(api_client)
-    generate_token_request = {"grant_type":"client_credentials"} # GenerateTokenRequest | Request Body to Generate OAuth Token
-    content_type="application/json"
-    try:
-        # Generate and Save Access Token
-        api_response = token_instance.generate_token(generate_token_request, content_type=content_type)
-        configuration.access_token = api_response.access_token
-        print(configuration.access_token)
-    except Exception as e:
-        print("Exception when generating access token: %s\n" % e)
+    # Exchange client credentials for an access token.
+    token_api = onelogin.OAuth2Api(api_client)
+    token = token_api.generate_token({"grant_type": "client_credentials"})
+    configuration.access_token = token.access_token
 
-    user_instance = onelogin.UsersV2Api(api_client)
-    try:
-        # List Users
-        api_response = user_instance.list_users2()
-        print("The response of UsersV2Api->list_users:\n")
-        pprint(api_response)
-    except Exception as e:
-        print("Exception when calling UsersV2Api->list_users: %s\n" % e)
-
-
+    # Now make authenticated calls.
+    users_api = onelogin.UsersV2Api(api_client)
+    pprint(users_api.list_users2())
 ```
 
 ## Authentication
 
-### OAuth2
+OneLogin uses OAuth2 client credentials. Generate a Client ID + Client Secret under **Security → API Credentials** in the OneLogin admin portal, with one of:
 
-OneLogin API uses OAuth2 for authorization. Your client credentials (Client ID and Client Secret) are used to request an access token, which is then used for subsequent API calls.
+- **Authentication Only** — Verify Factor, Generate SAML Assertion, Create Session Login Token, Log User Out
+- **Read Users** — `GET` on User, Role, Group resources
+- **Manage Users** — `GET`/`POST`/`PUT`/`DELETE` on User, Role, Group (no password management or role assignment)
+- **Read All** — read-only across all resources
+- **Manage All** — full access including password management and role assignment
 
-#### Available Scopes
+## Tests
 
-The OneLogin API supports the following scopes:
-
-- **Authentication Only**: Access to authentication endpoints only (Verify Factor, Generate SAML Assertion, Create Session Login Token, Log User Out)
-- **Read Users**: Access to GET calls for User, Role, and Group API resources
-- **Manage Users**: Access to GET, POST, PUT, and DELETE calls for User, Role, and Group API resources (except password management and role assignment)
-- **Manage All**: Full access to all API resources, including password management and role assignment
-- **Read All**: Read-only access to all API resources
-
-You can set up your API credentials with appropriate scopes in the OneLogin portal under Security > API Credentials.
+```sh
+pip install -e ".[test]"
+pytest
+```
 
 ## Troubleshooting
 
-### ImportError with Pydantic
-If you encounter an error like `ImportError: cannot import name validate_call from pydantic`, make sure you have Pydantic 2.11+ installed:
-
-```sh
-pip install pydantic>=2.11.0
-```
-
-### Environment Variable Names
-Make sure to set your environment variables using the names expected by your code:
-
-```sh
-export ONELOGIN_CLIENT_ID="your-client-id"
-export ONELOGIN_CLIENT_SECRET="your-client-secret"
-```
-
-### API Connection Issues
-If you're having trouble connecting to the API, double-check:
-- Your OneLogin subdomain is correct in the host URL
-- Your API credentials have the correct scopes for the operations you're trying to perform
-- Your network can reach the OneLogin API endpoints
+- **`ImportError: cannot import name validate_call from pydantic`** — Pydantic <2.11 in your environment. Run `pip install -U pydantic`.
+- **`ValidationError` on response deserialization** — likely a server-returned `null` for a field the SDK still types as required. Open an issue with the endpoint and a redacted response sample; this class of fix is straightforward (see PR #126, #131 for examples).
+- **Connection issues** — confirm your subdomain in the `host` URL, that your credentials carry the right scope, and that your network can reach `*.onelogin.com`.
 
 ## Release Process (Maintainers)
 
-To create a new release and publish to PyPI:
+Releases ship to PyPI automatically when you publish a GitHub Release. The publish workflow runs `sed -i` against `pyproject.toml` and `onelogin/__init__.py` *inside the CI runner* to set the version from the tag — those edits are **not committed back to `main`**, so the source tree may lag the latest PyPI release. Reconcile periodically with a manual version bump PR.
 
-1. Go to the [Releases page](../../releases) in GitHub
-2. Click **"Draft a new release"**
-3. Click **"Choose a tag"** and create a new tag following semantic versioning (e.g., `v3.2.3`)
-4. Set the release title and description (you can use "Generate release notes" for automatic changelog)
-5. Click **"Publish release"**
+1. Open the [Releases page](../../releases) and click **Draft a new release**
+2. Create a tag matching the version, e.g. `3.2.9` (no `v` prefix; matches releases 3.2.4 onward)
+3. Set title to the version and paste the CHANGELOG entry into the description
+4. **Publish release** — `.github/workflows/python-publish.yml` builds and uploads to PyPI
 
-The release workflow will automatically:
-- Extract the version from the tag (e.g., `v3.2.3` → `3.2.3`)
-- Update `version` in `pyproject.toml` and `__version__` in `onelogin/__init__.py`
-- Build the Python package (sdist and wheel)
-- Publish to PyPI using the configured `PYPI_API_TOKEN`
-
-**That's it!** The entire release process is automated from a single GitHub Release creation.
+If a release fails to upload, re-run the failed workflow from the Actions tab; the build is idempotent up to the point of `twine upload`.


### PR DESCRIPTION
## Summary

Trims the README from 163 to 85 lines and fixes two real inaccuracies.

## Bugs fixed

1. **Getting Started example was broken.** It created \`onelogin.Configuration(host=...)\`, then immediately *reassigned* the variable with a new \`Configuration(username=..., password=...)\` — losing the host setting. A user copy-pasting the example would silently hit the OneLogin default host instead of their own subdomain. Collapsed into a single \`Configuration()\` call.

2. **Release Process section was misleading.** It claimed the publish workflow "updates \`version\` in pyproject.toml and \`__version__\` in onelogin/__init__.py". Technically true — but the workflow runs \`sed -i\` inside the ephemeral CI runner and **never commits back to main**. That's exactly why the source tree kept drifting behind PyPI (the manual fix landed in PR #128). The section now states this plainly.

## Other cleanups

- Removed duplicate \"First, install the package\" instructions (Tests and Installation said the same thing).
- Dropped the per-dependency version list in Requirements — that belongs in \`pyproject.toml\`, not two places.
- Stripped auto-generated comment noise from the code example (\`# GenerateTokenRequest | Request Body to ...\`) and the redundant explicit \`content_type=\"application/json\"\` (it's the default).
- Added a pointer to \`docs/\` for per-endpoint documentation.
- Added \`[lint]\` to the dev install instructions (introduced in PR #130).
- Aligned the example tag format with current convention (\`3.2.9\`, not \`v3.2.9\` — only the legacy \`v3.2.0\` tag has the prefix).
- New ValidationError-on-response troubleshooting entry pointing at PR #126 / #131 as worked examples. That's the most common bug class with this SDK; a quick issue gets a quick fix.

## Verification

- [x] Every symbol the example references resolves: \`onelogin.Configuration\`, \`onelogin.ApiClient\`, \`onelogin.OAuth2Api.generate_token\`, \`onelogin.UsersV2Api.list_users2\` — checked via \`inspect\`.
- [x] \`pytest test/\` — 70 passed
- [x] \`ruff check .\` — clean

Confirmed reduction: 163 → 85 lines (51% smaller, more accurate).